### PR TITLE
add Parsely Analytics via script

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -8,6 +8,7 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { Grid } from "semantic-ui-react"
+import { Script } from "gatsby"
 
 import HeaderWrapper from "./header-wrapper"
 
@@ -45,6 +46,7 @@ const Layout = ({ children }) => (
         <span style={{ paddingBottom: '.25em' }}>Last updated {new Date().toLocaleDateString()}</span>
         <span>© Copyright {new Date().getFullYear()}, PublicSource</span>
       </div>
+      <Script id="parsely-analytics" src="https://cdn.parsely.com/keys/publicsource.org/p.js" />
     </footer>
   </>
 )


### PR DESCRIPTION
The Gatsby plugin for Parsely hasn't been updated in a long time and isn't compatible with latest v5. 

Instead, we can try adding Parsely via its' JS CDN scirpt:
- https://docs.parse.ly/tracking-code-setup/#h-javascript-snippet
- https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/

Will need to click around on this Netlify deploy preview to test if tracking working as expected or not! Markup looks good (last script within `<body>`): 
![Screenshot from 2025-04-06 19-10-48](https://github.com/user-attachments/assets/d96f2ab1-c4d7-4609-b4dd-e131ccd55f8e)