### PR TITLE
"Last updated" footer reflects Airtable stories

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,7 +9,7 @@ require("dotenv").config({
  */
 module.exports = {
   flags: {
-    DEV_SSR: true
+    DEV_SSR: false
   },
   siteMetadata: {
     title: `Board Explorer`,

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -14,7 +14,7 @@ import HeaderWrapper from "./header-wrapper"
 import 'semantic-ui-less/semantic.less'
 import "./layout.css"
 
-const Layout = ({ children }) => (
+const Layout = ({ lastUpdated, children }) => (
   <>
     <div style={{ minHeight: `100vh`, marginBottom: `-60px` }}>
       <HeaderWrapper />
@@ -42,7 +42,7 @@ const Layout = ({ children }) => (
         height: `60px`,
       }}>
       <div style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
-        <span style={{ paddingBottom: '.25em' }}>Last updated {new Date().toLocaleDateString()}</span>
+        {lastUpdated && <span style={{ paddingBottom: '.25em' }}>Last updated {lastUpdated}</span>}
         <span>© Copyright {new Date().getFullYear()}, PublicSource</span>
       </div>
     </footer>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,11 +1,12 @@
+import { graphql } from "gatsby"
 import React from "react"
 import { Header, Grid } from "semantic-ui-react"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
-const AboutPage = () => (
-  <Layout>
+const AboutPage = ({ data }) => (
+  <Layout lastUpdated={data.stories.edges[0].node.data.Date}>
     <Grid.Row style={{ marginTop: `1em`, display: 'flex', flexDirection: 'column' }}>
       <Header as='h1' style={{ borderBottom: `5px solid #418cff`, width: `100%` }}>About</Header>
       <p>The Pittsburgh region is run in large part by more than 500 unelected board members of authorities, commissions and other governmental agencies.</p>
@@ -19,6 +20,20 @@ const AboutPage = () => (
     </Grid.Row>
   </Layout>
 )
+
+export const query = graphql`
+  query AllNodesQuery {
+    stories: allAirtable(filter: {table: {eq: "Stories"}}, sort: {data: {Date: DESC}}, limit: 1) {
+      totalCount
+      edges {
+        node {
+          data {
+            Date(formatString: "M/D/YYYY")
+          }
+        }
+      }
+    }
+  }`;
 
 export default AboutPage
 

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -1,17 +1,32 @@
+import { graphql } from "gatsby"
 import React from "react"
 import { Header, Grid } from "semantic-ui-react"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 
-const ContactPage = () => (
-  <Layout>
+const ContactPage = ({ data }) => (
+  <Layout lastUpdated={data.stories.edges[0].node.data.Date}>
     <Grid.Row style={{ marginTop: `1em`, display: 'flex', flexDirection: 'column' }}>
       <Header as='h1' style={{ borderBottom: `5px solid #418cff`, width: `100%` }}>Contact</Header>
       <p>Do you have a question about Board Explorer or want to request a correction? Contact <a style={{ borderBottom: `2px solid #418cff` }} target="_blank" rel="noopener noreferrer" href="mailto:rich@publicsource.org">rich@publicsource.org</a>.</p>
     </Grid.Row>
   </Layout>
 )
+
+export const query = graphql`
+  query AllNodesQuery {
+    stories: allAirtable(filter: {table: {eq: "Stories"}}, sort: {data: {Date: DESC}}, limit: 1) {
+      totalCount
+      edges {
+        node {
+          data {
+            Date(formatString: "M/D/YYYY")
+          }
+        }
+      }
+    }
+  }`;
 
 export default ContactPage
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,6 +17,7 @@ const IndexPage = ({ data }) => {
 
   // Stories
   let stories = data.stories.edges.map(e => e.node.data)
+  const lastUpdatedStoryDate = new Date(stories[0].Date).toLocaleDateString(); // GraphQL query sorted DESC by default
 
   // Chart controls
   let chartOptions = [
@@ -40,7 +41,7 @@ const IndexPage = ({ data }) => {
   const [chartFilter, setChartFilter] = useState('All');
 
   return (
-    <Layout>
+    <Layout lastUpdated={lastUpdatedStoryDate}>
       <Grid.Row style={{ marginTop: `1em` }}>
         <Grid.Column>
           <Header as='h2' style={{ borderBottom: `5px solid #418cff`, width: `100%` }}>
@@ -170,12 +171,6 @@ export const query = graphql`
             Date(formatString: "MMMM D, YYYY")
             Link
             Boards {
-              data {
-                Name
-                Slug
-              }
-            }
-            Person {
               data {
                 Name
                 Slug

--- a/src/templates/board-page.js
+++ b/src/templates/board-page.js
@@ -28,7 +28,7 @@ const BoardPage = ({ data }) => {
   )
 
   return (
-    <Layout>
+    <Layout lastUpdated={data.globalLastStory.edges[0].node.data.Date}>
       <Grid.Row style={{ marginTop: `1em`, display: 'flex', flexDirection: 'column' }}>
         <Grid.Column>
           <Breadcrumb>
@@ -171,6 +171,16 @@ export const query = graphql`
                 Date(formatString: "MMMM D, YYYY")
               }
             }
+          }
+        }
+      }
+    }
+    globalLastStory: allAirtable(filter: {table: {eq: "Stories"}}, sort: {data: {Date: DESC}}, limit: 1) {
+      totalCount
+      edges {
+        node {
+          data {
+            Date(formatString: "M/D/YYYY")
           }
         }
       }

--- a/src/templates/person-page.js
+++ b/src/templates/person-page.js
@@ -35,7 +35,7 @@ const PersonPage = ({ data }) => {
   let expiredPositions = _.filter(person.Positions, p => p.data.Expired === true)
 
   return (
-    <Layout>
+    <Layout lastUpdated={data.globalLastStory.edges[0].node.data.Date}>
       <Grid.Row style={{ marginTop: `1em`, display: 'flex', flexDirection: 'column' }}>
         <Grid.Column>
           <Breadcrumb>
@@ -210,6 +210,16 @@ export const query = graphql`
                 }
               }
             }
+          }
+        }
+      }
+    }
+    globalLastStory: allAirtable(filter: {table: {eq: "Stories"}}, sort: {data: {Date: DESC}}, limit: 1) {
+      totalCount
+      edges {
+        node {
+          data {
+            Date(formatString: "M/D/YYYY")
           }
         }
       }


### PR DESCRIPTION
The "last updated" in the footer was incorrectly always displaying today's date (despite being a statically rendered site), so instead it's now based on the most recent "Story" in Airtable. 

The footer consistently shows this date throughout all pages, "board" and "person" page footers do not currently show dates specific to their unique content.